### PR TITLE
Don't apply ligatures in fundamental-mode.

### DIFF
--- a/pragmatapro-lig.el
+++ b/pragmatapro-lig.el
@@ -326,6 +326,7 @@
 
 (defun pragmatapro-update-ligatures (start end &optional l)
   "Update ligatures in start-end in the current buffer"
+  (unless (eq major-mode 'fundamental-mode)
   (let ((modified (buffer-modified-p))
         (inhibit-read-only t)
         (case-fold-search nil))
@@ -355,7 +356,7 @@
                         (put-text-property (+ s i) (+ s i 1) 'display
                                            (aref th i)))
                       (throw 'break nil))))))))))
-    (set-buffer-modified-p modified)))
+    (set-buffer-modified-p modified))))
 
 (define-minor-mode pragmatapro-lig-mode
   "Compose pragmatapro's ligatures."


### PR DESCRIPTION
Some emacs functionality does its processing in a buffer, rather than just a string.  This code doesn't always like having its data modified underneath it, meaning that updating the ligatures while such processing occurs results in chaos.

The only case where this has shown up for me so far involved a fundamental-mode buffer created by mail-extract-address-components as called by org-capture in a Notmuch window.  So, as a workaround I have just disabled ligatures in fundamental-mode.

Maybe this is too extreme, and there is a more targeted way to deal with the problem, but I nevertheless wanted to feed this back upstream.